### PR TITLE
Standardize slash command output to use markdown formatting

### DIFF
--- a/src/agent/commands/AgentCommand.ts
+++ b/src/agent/commands/AgentCommand.ts
@@ -67,20 +67,17 @@ export class AgentCommand extends Command {
   private showHelp(): CommandResult {
     return {
       handled: true,
-      response: `Agent Commands:
+      response: `**Specialized Agents**
+\`/agent create\`  Create new specialized agent
+\`/agent list\`  List available agents
+\`/agent show <name>\`  Show agent details
+\`/agent use <name> <task>\`  Run task with agent
+\`/agent delete <name>\`  Delete agent
 
-Specialized Agent Management:
-  /agent create <description> - Create new specialized agent
-  /agent list                 - List available agents
-  /agent show <name>          - Show agent details
-  /agent use <name> <task>    - Use specific agent
-  /agent delete <name>        - Delete agent
-
-Agent Pool Management:
-  /agent active               - Show active pooled agents
-  /agent stats                - Show pool statistics
-  /agent clear [agent_id]     - Clear specific agent or all if no ID
-`,
+**Agent Pool**
+\`/agent active\`  Show active pooled agents
+\`/agent stats\`  Show pool statistics
+\`/agent clear [id]\`  Clear specific agent or all`,
     };
   }
 
@@ -105,14 +102,16 @@ Agent Pool Management:
     if (agents.length === 0) {
       return {
         handled: true,
-        response: 'No agents available. Use /agent create to create one.',
+        response: 'No agents available. Use `/agent create` to create one.',
       };
     }
 
-    let output = 'Available Agents:\n\n';
+    let output = '**Available Agents**\n\n';
+    output += '| Name | Description |\n';
+    output += '|------|-------------|\n';
 
     for (const agent of agents) {
-      output += `  - ${agent.name}: ${agent.description}\n`;
+      output += `| ${agent.name} | ${agent.description} |\n`;
     }
 
     // Multi-line output, not yellow
@@ -138,10 +137,12 @@ Agent Pool Management:
       };
     }
 
-    let output = `Agent: ${agent.name}\n\n`;
-    output += `Description: ${agent.description}\n`;
-    output += `Created: ${agent.created_at || 'Unknown'}\n\n`;
-    output += `System Prompt:\n${agent.system_prompt}\n`;
+    let output = `**Agent: ${agent.name}**\n\n`;
+    output += `| Property | Value |\n`;
+    output += `|----------|-------|\n`;
+    output += `| Description | ${agent.description} |\n`;
+    output += `| Created | ${agent.created_at || 'Unknown'} |\n\n`;
+    output += `**System Prompt**\n\`\`\`\n${agent.system_prompt}\n\`\`\``;
 
     // Multi-line output, not yellow
     return { handled: true, response: output };
@@ -226,7 +227,9 @@ Agent Pool Management:
       };
     }
 
-    let output = 'Active Agents:\n\n';
+    let output = '**Active Agents**\n\n';
+    output += '| ID | Status | Type | Age | Last Used | Uses |\n';
+    output += '|----|--------|------|-----|-----------|------|\n';
 
     for (const agentId of agentIds) {
       const metadata = agentPool.getAgentMetadata(agentId);
@@ -237,13 +240,7 @@ Agent Pool Management:
       const age = this.formatDuration(Date.now() - metadata.createdAt);
       const lastUsed = this.formatDuration(Date.now() - metadata.lastAccessedAt);
 
-      output += `  ${agentId}\n`;
-      output += `    Status:      ${status}\n`;
-      output += `    Type:        ${type}\n`;
-      output += `    Age:         ${age}\n`;
-      output += `    Last Used:   ${lastUsed}\n`;
-      output += `    Use Count:   ${metadata.useCount}\n`;
-      output += '\n';
+      output += `| ${agentId} | ${status} | ${type} | ${age} | ${lastUsed} | ${metadata.useCount} |\n`;
     }
 
     // Multi-line output, not yellow
@@ -261,16 +258,18 @@ Agent Pool Management:
 
     const stats = agentPool.getPoolStats();
 
-    let output = 'Agent Pool Statistics:\n\n';
-    output += `  Total Agents:     ${stats.totalAgents}/${stats.maxPoolSize}\n`;
-    output += `  In Use:           ${stats.inUseAgents}\n`;
-    output += `  Available:        ${stats.availableAgents}\n`;
+    let output = '**Agent Pool Statistics**\n\n';
+    output += '| Metric | Value |\n';
+    output += '|--------|-------|\n';
+    output += `| Total Agents | ${stats.totalAgents}/${stats.maxPoolSize} |\n`;
+    output += `| In Use | ${stats.inUseAgents} |\n`;
+    output += `| Available | ${stats.availableAgents} |\n`;
 
     if (stats.oldestAgentAge !== null) {
-      output += `  Oldest Agent:     ${this.formatDuration(stats.oldestAgentAge)}\n`;
+      output += `| Oldest Agent | ${this.formatDuration(stats.oldestAgentAge)} |\n`;
     }
     if (stats.newestAgentAge !== null) {
-      output += `  Newest Agent:     ${this.formatDuration(stats.newestAgentAge)}\n`;
+      output += `| Newest Agent | ${this.formatDuration(stats.newestAgentAge)} |\n`;
     }
 
     // Multi-line output, not yellow

--- a/src/agent/commands/PluginCommand.ts
+++ b/src/agent/commands/PluginCommand.ts
@@ -518,12 +518,14 @@ export class PluginCommand extends Command {
         };
       }
 
-      let output = 'Active Plugins:\n\n';
+      let output = '**Active Plugins**\n\n';
+      output += '| Plugin | Mode |\n';
+      output += '|--------|------|\n';
 
       for (const pluginName of activePlugins) {
         const mode = activationManager.getActivationMode(pluginName);
-        const modeBadge = mode === 'always' ? '[always]' : '[tagged]';
-        output += `  ${pluginName} ${modeBadge}\n`;
+        const modeBadge = mode === 'always' ? 'always' : 'tagged';
+        output += `| ${pluginName} | ${modeBadge} |\n`;
       }
 
       return {
@@ -608,18 +610,21 @@ export class PluginCommand extends Command {
   private showHelp(): CommandResult {
     return {
       handled: true,
-      response: `Plugin Management Commands:
+      response: `**Plugin Management**
+\`/plugin list\`  List all installed plugins
+\`/plugin show <name>\`  Show detailed plugin information
+\`/plugin active\`  List active plugins in this session
+\`/plugin config <name>\`  Configure a plugin
 
-  /plugin list                    List all installed plugins
-  /plugin show <name>             Show detailed plugin information
-  /plugin install <path|url>      Install a plugin
-  /plugin uninstall <name>        Uninstall a plugin
-  /plugin config <name>           Configure a plugin
-  /plugin active                  List active plugins in this session
-  /plugin activate <name>         Activate a plugin
-  /plugin deactivate <name>       Deactivate a plugin
+**Installation**
+\`/plugin install <path>\`  Install a plugin
+\`/plugin uninstall <name>\`  Uninstall a plugin
 
-Use +plugin-name to activate or -plugin-name to deactivate`,
+**Activation**
+\`/plugin activate <name>\`  Activate a plugin
+\`/plugin deactivate <name>\`  Deactivate a plugin
+\`+plugin-name\`  Quick activate in message
+\`-plugin-name\`  Quick deactivate in message`,
     };
   }
 }

--- a/src/agent/commands/ProfileCommand.ts
+++ b/src/agent/commands/ProfileCommand.ts
@@ -64,19 +64,17 @@ export class ProfileCommand extends Command {
       const profile = await profileManager.loadProfile(activeProfileName);
       const stats = await profileManager.getProfileStats(activeProfileName);
 
-      let output = '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
-      output += `  Current Profile: ${profile.name}\n`;
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
+      let output = `**Current Profile: ${profile.name}**\n\n`;
 
       if (profile.description) {
-        output += `  ${profile.description}\n\n`;
+        output += `${profile.description}\n\n`;
       }
 
-      output += `  Active Plugins:  ${stats.plugin_count}\n`;
-      output += `  Custom Agents:   ${stats.agent_count}\n`;
-      output += `  Prompts:         ${stats.prompt_count}\n\n`;
-
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
+      output += '| Resource | Count |\n';
+      output += '|----------|-------|\n';
+      output += `| Plugins | ${stats.plugin_count} |\n`;
+      output += `| Agents | ${stats.agent_count} |\n`;
+      output += `| Prompts | ${stats.prompt_count} |\n`;
 
       return this.createResponse(output);
     } catch (error) {
@@ -99,22 +97,19 @@ export class ProfileCommand extends Command {
     try {
       const profiles = await profileManager.listProfiles();
 
-      let output = '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
-      output += '  Available Profiles\n';
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
+      let output = '**Available Profiles**\n\n';
+      output += '| Profile | Description | Plugins | Agents |\n';
+      output += '|---------|-------------|---------|--------|\n';
 
       for (const profile of profiles) {
-        const current = profile.name === activeProfileName ? ' (current session)' : '';
-        output += `  ${profile.name}${current}\n`;
-        if (profile.description) {
-          output += `    ${profile.description}\n`;
-        }
-        output += `    ${profile.plugin_count} plugins, ${profile.agent_count} agents\n\n`;
+        const current = profile.name === activeProfileName ? ' ●' : '';
+        const description = profile.description || '-';
+        output += `| ${profile.name}${current} | ${description} | ${profile.plugin_count} | ${profile.agent_count} |\n`;
       }
 
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
-      output += 'To switch profiles, exit and relaunch:\n';
-      output += '  ally --profile <name>\n\n';
+      output += '\n---\n\n';
+      output += '**Switch Profile**\n';
+      output += '`ally --profile <name>`  Launch with different profile';
 
       return this.createResponse(output);
     } catch (error) {
@@ -141,28 +136,27 @@ export class ProfileCommand extends Command {
       const profile = await profileManager.loadProfile(targetProfile);
       const stats = await profileManager.getProfileStats(targetProfile);
 
-      let output = '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n';
-      output += `  Profile: ${profile.name}\n`;
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
+      let output = `**Profile: ${profile.name}**\n\n`;
 
       if (profile.description) {
-        output += `  Description: ${profile.description}\n\n`;
+        output += `${profile.description}\n\n`;
       }
 
-      output += `  Created: ${new Date(profile.created_at).toLocaleString()}\n`;
-      output += `  Updated: ${new Date(profile.updated_at).toLocaleString()}\n\n`;
-
-      output += `  Plugins:  ${stats.plugin_count}\n`;
-      output += `  Agents:   ${stats.agent_count}\n`;
-      output += `  Prompts:  ${stats.prompt_count}\n`;
-      output += `  Config Overrides: ${stats.config_overrides}\n\n`;
+      output += '| Property | Value |\n';
+      output += '|----------|-------|\n';
+      output += `| Created | ${new Date(profile.created_at).toLocaleString()} |\n`;
+      output += `| Updated | ${new Date(profile.updated_at).toLocaleString()} |\n`;
+      output += `| Plugins | ${stats.plugin_count} |\n`;
+      output += `| Agents | ${stats.agent_count} |\n`;
+      output += `| Prompts | ${stats.prompt_count} |\n`;
+      output += `| Config Overrides | ${stats.config_overrides} |\n`;
 
       if (profile.tags && profile.tags.length > 0) {
-        output += `  Tags: ${profile.tags.join(', ')}\n\n`;
+        output += `| Tags | ${profile.tags.join(', ')} |\n`;
       }
 
-      output += '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n';
-      output += `Launch with: ally --profile ${profile.name}\n\n`;
+      output += '\n---\n\n';
+      output += `**Launch**\n\`ally --profile ${profile.name}\``;
 
       return this.createResponse(output);
     } catch (error) {
@@ -174,16 +168,14 @@ export class ProfileCommand extends Command {
    * Show help for profile commands
    */
   private showHelp(): CommandResult {
-    const output =
-      '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
-      '  Profile Commands\n' +
-      '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n' +
-      '  /profile              Show current profile\n' +
-      '  /profile list         List all profiles\n' +
-      '  /profile info [name]  Show profile info\n\n' +
-      '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n' +
-      'Profile switching is launch-time only.\n' +
-      'To switch: ally --profile <name>\n\n';
+    const output = `**Profile Commands**
+\`/profile\`  Show current profile
+\`/profile list\`  List all profiles
+\`/profile info [name]\`  Show profile details
+
+**Switch Profile**
+Profile switching is launch-time only.
+\`ally --profile <name>\`  Launch with different profile`;
 
     return this.createResponse(output);
   }

--- a/src/agent/commands/PromptCommand.ts
+++ b/src/agent/commands/PromptCommand.ts
@@ -251,24 +251,26 @@ export class PromptCommand extends Command {
       if (prompts.length === 0) {
         return {
           handled: true,
-          response: 'No saved prompts. Use /prompt add to create one.',
+          response: 'No saved prompts. Use `/prompt add` to create one.',
         };
       }
 
-      let output = 'Saved Prompts:\n\n';
+      let output = '**Saved Prompts**\n\n';
+      output += '| ID | Title | Tags | Created |\n';
+      output += '|----|-------|------|----------|\n';
 
       prompts.forEach(prompt => {
         const date = new Date(prompt.createdAt).toLocaleDateString();
-        const tags = prompt.tags && prompt.tags.length > 0 ? ` [${prompt.tags.join(', ')}]` : '';
-        const preview = prompt.content.length > 60
-          ? prompt.content.substring(0, 60) + '...'
-          : prompt.content;
+        const tags = prompt.tags && prompt.tags.length > 0 ? prompt.tags.join(', ') : '-';
 
-        output += `  ${prompt.id}\n`;
-        output += `    ${prompt.title}${tags}\n`;
-        output += `    ${preview}\n`;
-        output += `    Created: ${date}\n\n`;
+        output += `| \`${prompt.id}\` | ${prompt.title} | ${tags} | ${date} |\n`;
       });
+
+      output += '\n---\n\n';
+      output += '**Commands**\n';
+      output += '`/prompt <id>`  Insert prompt\n';
+      output += '`/prompt edit <id>`  Edit prompt\n';
+      output += '`/prompt delete <id>`  Delete prompt';
 
       return {
         handled: true,

--- a/src/agent/commands/TaskCommand.ts
+++ b/src/agent/commands/TaskCommand.ts
@@ -63,13 +63,13 @@ export class TaskCommand extends Command {
    * Get usage text
    */
   private getUsageText(): string {
-    return `Usage:
-  /task list, ls          List all running background processes
-  /task kill <shell_id>   Kill a background process by ID
+    return `**Background Tasks**
+\`/task list\`  List running background processes
+\`/task kill <id>\`  Kill a background process
 
-Examples:
-  /task list
-  /task kill shell-1234567890-abc123`;
+**Examples**
+\`/task list\`
+\`/task kill shell-1234567890-abc123\``;
   }
 
   /**
@@ -92,7 +92,9 @@ Examples:
       };
     }
 
-    let output = `Background Processes (${runningProcesses.length} running):\n\n`;
+    let output = `**Background Processes** (${runningProcesses.length} running)\n\n`;
+    output += '| # | ID | Command | PID | Running |\n';
+    output += '|---|-----|---------|-----|----------|\n';
 
     const now = Date.now();
     runningProcesses.forEach((proc, index) => {
@@ -103,12 +105,13 @@ Examples:
         ? proc.id.substring(6, 14) // Show first 8 digits after "shell-"
         : proc.id;
 
-      output += `  ${index + 1}. [${shortId}] ${proc.command}\n`;
-      output += `     PID: ${proc.pid} | Running for: ${elapsed}\n`;
-      output += `     Kill: /task kill ${proc.id}\n\n`;
+      output += `| ${index + 1} | \`${shortId}\` | ${proc.command} | ${proc.pid} | ${elapsed} |\n`;
     });
 
-    output += `Use bash-output(shell_id="<id>") to read process output`;
+    output += '\n---\n\n';
+    output += '**Commands**\n';
+    output += '`/task kill <full-id>`  Kill a process\n';
+    output += '`bash-output(shell_id="<id>")`  Read process output';
 
     return {
       handled: true,

--- a/src/agent/commands/TodoCommand.ts
+++ b/src/agent/commands/TodoCommand.ts
@@ -79,35 +79,35 @@ export class TodoCommand extends Command {
       // Not using yellow output for this message (it's not a status update)
       return {
         handled: true,
-        response: 'No todos. Use /todo add <task> to add one.',
+        response: 'No todos. Use `/todo add <task>` to add one.',
       };
     }
-
-    let output = 'Todo List:\n\n';
 
     const inProgress = todoManager.getInProgressTodo();
     const pending = todos.filter(t => t.status === 'pending');
     const completed = todoManager.getCompletedTodos();
 
+    let output = '**Todo List**\n\n';
+
     // Show in-progress task (highlighted)
     if (inProgress) {
-      output += `  → IN PROGRESS: ${inProgress.task}\n\n`;
+      output += `**In Progress**\n→ ${inProgress.task}\n\n`;
     }
 
     // Show pending tasks with indices
     if (pending.length > 0) {
-      output += 'Pending:\n';
+      output += '**Pending**\n';
       pending.forEach((todo, index) => {
-        output += `  ${index}. ${todo.task}\n`;
+        output += `\`${index}\`  ${todo.task}\n`;
       });
       output += '\n';
     }
 
     // Show completed tasks
     if (completed.length > 0) {
-      output += 'Completed:\n';
+      output += '**Completed**\n';
       completed.forEach(todo => {
-        output += `  ✓ ${todo.task}\n`;
+        output += `✓ ${todo.task}\n`;
       });
     }
 


### PR DESCRIPTION
Update all multi-line command outputs to follow /help's markdown style:
- Use **bold** section headers
- Use `backtick` for commands and code
- Use markdown tables for structured data
- Use --- horizontal rules for sections

Commands updated:
- /agent (help, list, show, active, stats)
- /todo (display)
- /prompt list
- /task (help, list)
- /plugin (help, active)
- /profile (current, list, info, help)